### PR TITLE
Update Plugin.php

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -7,6 +7,7 @@ use System\Classes\SettingsManager;
 
 class Plugin extends PluginBase
 {
+    public $require = ['vojtasvoboda.twigextensions'];
     public function registerComponents()
     {
         return [


### PR DESCRIPTION
Upt required, because plugin cant use {{ config('cms.backendUri')|app }}" {{ trans('backend::lang.dashboard.menu_label') }} without twig extension